### PR TITLE
ImportError: No module named ez_setup

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include ez_setup.py


### PR DESCRIPTION
When running

```
pip install django_template_coverage I receive an error about no ez_setup module.
```

The package on PyPI does not include ez_setup.py.
